### PR TITLE
Improves compatibility among different C compilers. (digit separator)

### DIFF
--- a/msf_gif.h
+++ b/msf_gif.h
@@ -560,7 +560,7 @@ static void msf_free_gif_state(MsfGifState * handle) {
 int msf_gif_begin(MsfGifState * handle, int width, int height) { MsfTimeFunc
     //To help avoid potential overflow errors, let's just not even try to support images larger than 1GB in size.
     //And let's also reject images with width or height more or less than what the gif format itself supports.
-    const int MAX_PIXELS = 268'435'456; //2^30 / 4 = 1GB / bytesPerPixel
+    const int MAX_PIXELS = 268435456; //2^30 / 4 = 1GB / bytesPerPixel
     if (width < 1 || height < 1 || width > 65535 || height > 65535 || width >= MAX_PIXELS / height) {
         handle->listHead = NULL; //this implicitly marks the handle as invalid until the next msf_gif_begin() call
         return 0;


### PR DESCRIPTION
The numeric literal digit separator (') is a feature of C++14, but not of C89/C99/C11. So I change to improve compatibility.
```
msf_gif.h: In function ‘msf_gif_begin’:
msf_gif.h:563:31: warning: multi-character character constant [-Wmultichar]
  563 |     const int MAX_PIXELS = 268'435'456; //2^30 / 4 = 1GB / bytesPerPixel
      |                               ^~~~~
msf_gif.h:563:31: error: expected ‘,’ or ‘;’ before '\x343335'
```